### PR TITLE
feat: add weekly limit validator for faucet claims

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,24 +1,40 @@
-# https://docs.google.com/document/d/1K5TbGKPmH0Cb5DNsf_uwY85K3gOw0310SxECDHgnB_c/edit?tab=t.0
-PARTNER_API_KEY=
+# QuickNode API Configuration
+QUICKNODE_API_URL=https://api.faucet.quicknode.com
 
-ALLOWED_ORIGINS=http://localhost:5173,http://localhost:3000
+# Server Configuration
+PORT=8080
+LOG_LEVEL=info
+CONFIG_PATH=./config.json
 
-# NFT contract address and RPC URL
-NFT_CONTRACT_ADDRESS=0x7DB790B55299b474c2269105Ff6Cd48f56520a2A
-RPC_URL=https://rpc.dev.gblend.xyz
-TOKEN_ID=1
-
-# Para secret API key and JWKS URL
-PARA_SECRET_KEY=sk_beta_
-PARA_JWKS_URL=https://api.beta.getpara.com/.well-known/jwks.json
-
-# QuickNode distributor API
-DISTRIBUTOR_API_KEY=
-DISTRIBUTOR_ID=
-
-# Postgres DB
+# Database Configuration
 POSTGRES_USER=faucet
 POSTGRES_PASSWORD=faucetpass
 POSTGRES_DB=faucetdb
 POSTGRES_PORT=5432
 DATABASE_URL=postgresql://faucet:faucetpass@postgres:5432/faucetdb
+
+# ============================================
+# PROJECT: PUMP PALS
+# ============================================
+
+# Pump Pals - Pre-fund Faucet (one-time claim)
+PUMP_PALS_PREFUND_DIST_ID=your-distributor-id-here
+PUMP_PALS_PREFUND_API_KEY=your-api-key-here
+
+# Pump Pals - Weekly Faucet (3x per week)
+PUMP_PALS_WEEKLY_DIST_ID=your-weekly-distributor-id-here
+PUMP_PALS_WEEKLY_API_KEY=your-weekly-api-key-here
+
+# Pump Pals - Para Authentication
+PUMP_PALS_PARA_SECRET_KEY=sk_beta_your_para_key_here
+
+# ============================================
+# PROJECT: EXAMPLE PROJECT (template for new projects)
+# ============================================
+
+# Example - Main Faucet
+# EXAMPLE_PROJECT_MAIN_DIST_ID=
+# EXAMPLE_PROJECT_MAIN_API_KEY=
+
+# Example - Para Authentication  
+# EXAMPLE_PROJECT_PARA_SECRET_KEY=sk_beta_

--- a/config/production.json
+++ b/config/production.json
@@ -3,8 +3,9 @@
 
   "distributors": {
     "/claim": {
-      "distributorId": "${PUMP_PALS_DISTRIBUTOR_ID}",
-      "distributorApiKey": "${PUMP_PALS_DISTRIBUTOR_API_KEY}",
+      "distributorId": "${PUMP_PALS_PREFUND_DIST_ID}",
+      "distributorApiKey": "${PUMP_PALS_PREFUND_API_KEY}",
+      "name": "Pump Pals Pre-Fund Faucet",
       "dripAmount": 0.5,
       "validators": {
         "para-account": {
@@ -13,6 +14,47 @@
           "paraVerifyUrl": "https://api.beta.getpara.com/wallets/verify"
         },
         "once-only": {},
+        "nft-ownership": {
+          "contractAddress": "0x27BE45b6a8deB80CD8636272eb62FA4aA9e5Ee34",
+          "tokenId": "1",
+          "rpcUrl": "https://rpc.dev.gblend.xyz"
+        }
+      }
+    },
+    "/pump-pals/pre-fund": {
+      "distributorId": "${PUMP_PALS_PREFUND_DIST_ID}",
+      "distributorApiKey": "${PUMP_PALS_PREFUND_API_KEY}",
+      "name": "Pump Pals Pre-Fund Faucet",
+      "dripAmount": 0.5,
+      "validators": {
+        "para-account": {
+          "paraSecretKey": "${PUMP_PALS_PARA_SECRET_KEY}",
+          "paraJwksUrl": "https://api.beta.getpara.com/.well-known/jwks.json",
+          "paraVerifyUrl": "https://api.beta.getpara.com/wallets/verify"
+        },
+        "once-only": {},
+        "nft-ownership": {
+          "contractAddress": "0x27BE45b6a8deB80CD8636272eb62FA4aA9e5Ee34",
+          "tokenId": "1",
+          "rpcUrl": "https://rpc.dev.gblend.xyz"
+        }
+      }
+    },
+    "/pump-pals/weekly": {
+      "distributorId": "${PUMP_PALS_WEEKLY_DIST_ID}",
+      "distributorApiKey": "${PUMP_PALS_WEEKLY_API_KEY}",
+      "name": "Pump Pals Weekly Faucet",
+      "dripAmount": 0.15,
+      "validators": {
+        "para-account": {
+          "paraSecretKey": "${PUMP_PALS_PARA_SECRET_KEY}",
+          "paraJwksUrl": "https://api.beta.getpara.com/.well-known/jwks.json",
+          "paraVerifyUrl": "https://api.beta.getpara.com/wallets/verify"
+        },
+        "weekly-limit": {
+          "maxClaimsPerWeek": 3,
+          "cooldownHours": 24
+        },
         "nft-ownership": {
           "contractAddress": "0x27BE45b6a8deB80CD8636272eb62FA4aA9e5Ee34",
           "tokenId": "1",


### PR DESCRIPTION
Adds a weekly limit validator to control faucet claim frequency. Users can now claim up to 3 times per week with a 24-hour cooldown between claims.

## Changes

- Added `weekly-limit` validator with configurable max claims per week and cooldown period
- Updated database queries to use case-insensitive wallet address comparison
- Added new composite index for optimized weekly limit queries
- Configured two new endpoints: `/pump-pals/pre-fund` (one-time) and `/pump-pals/weekly` (3x/week)
- Migrated environment variables to new naming convention: `{PROJECT}_{TYPE}_{FIELD}`

## Technical Details

- All wallet addresses now stored in lowercase for consistency
- Backward compatible with existing mixed-case addresses using `LOWER()` in queries
- New index structure optimized for both once-only and weekly-limit validators