### PR TITLE
feat(privy): pay zerodev kernel smart account

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,11 +1,14 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "quicknode-faucet-distributor-backend",
       "dependencies": {
         "@elysiajs/cors": "^1.3.3",
         "@getpara/server-sdk": "^1.18.1",
+        "@zerodev/ecdsa-validator": "^5.4.9",
+        "@zerodev/sdk": "^5.5.10",
         "axios": "^1.6.8",
         "discord.js": "^14.21.0",
         "dotenv": "17.2.0",
@@ -17,6 +20,7 @@
         "pino-pretty": "^13.1.1",
         "postgres": "^3.4.7",
         "prisma": "^6.13.0",
+        "tslib": "^2.8.1",
         "viem": "^2.33.2",
         "zod": "^4.0.14",
       },
@@ -246,6 +250,10 @@
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.39.0", "", { "dependencies": { "@typescript-eslint/types": "8.39.0", "eslint-visitor-keys": "^4.2.1" } }, "sha512-ldgiJ+VAhQCfIjeOgu8Kj5nSxds0ktPOSO9p4+0VDH2R2pLvQraaM5Oen2d7NxzMCm+Sn/vJT+mv2H5u6b/3fA=="],
 
     "@vladfrangu/async_event_emitter": ["@vladfrangu/async_event_emitter@2.4.6", "", {}, "sha512-RaI5qZo6D2CVS6sTHFKg1v5Ohq/+Bo2LZ5gzUEwZ/WkHhwtGTCB/sVLw8ijOkAUxasZ+WshN/Rzj4ywsABJ5ZA=="],
+
+    "@zerodev/ecdsa-validator": ["@zerodev/ecdsa-validator@5.4.9", "", { "peerDependencies": { "@zerodev/sdk": "^5.4.13", "viem": "^2.28.0" } }, "sha512-9NVE8/sQIKRo42UOoYKkNdmmHJY8VlT4t+2MHD2ipLg21cpbY9fS17TGZh61+Bl3qlqc8pP23I6f89z9im7kuA=="],
+
+    "@zerodev/sdk": ["@zerodev/sdk@5.5.10", "", { "dependencies": { "semver": "^7.6.0" }, "peerDependencies": { "viem": "^2.28.0" } }, "sha512-WVyj2XR9F6zK2GdXrvappx7yo6zoJ46cWe42dOIArp3xDjFBninjA4O1O94MwohB0G+yFqtXNsEU+WxdE67SgQ=="],
 
     "abitype": ["abitype@1.0.8", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3 >=3.22.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg=="],
 

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -23,7 +23,8 @@
       "validators": {
         "privy-account": {
           "jwksUrl": "https://auth.privy.io/api/v1/apps/${PRIVY_APP_ID}/jwks.json",
-          "appId": "${PRIVY_APP_ID}"
+          "appId": "${PRIVY_APP_ID}",
+          "smartAccount": { "kernelVersion": "0.3.3", "index": 0 }
         },
         "time-limit": {
           "period": "week",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   "dependencies": {
     "@elysiajs/cors": "^1.3.3",
     "@getpara/server-sdk": "^1.18.1",
+    "@zerodev/ecdsa-validator": "^5.4.9",
+    "@zerodev/sdk": "^5.5.10",
     "axios": "^1.6.8",
     "discord.js": "^14.21.0",
     "dotenv": "17.2.0",
@@ -29,6 +31,7 @@
     "pino-pretty": "^13.1.1",
     "postgres": "^3.4.7",
     "prisma": "^6.13.0",
+    "tslib": "^2.8.1",
     "viem": "^2.33.2",
     "zod": "^4.0.14"
   },

--- a/src/distributor.ts
+++ b/src/distributor.ts
@@ -16,6 +16,7 @@ import {
   type ParaJwtPayload,
   type PrivyJwtPayload,
 } from "./utils/jwtValidator";
+import { deriveKernelAddress } from "./utils/smartAccount";
 import { NFTOwnershipValidator } from "./validators/nft";
 import { OnceOnlyValidator, TimeLimitValidator } from "./validators/time";
 
@@ -60,9 +61,16 @@ const ParaConfigSchema = z.object({
   secretKey: z.string().optional(),
 });
 
+// EntryPoint 0.7 supports Kernel v3 only - @zerodev/sdk GetKernelVersion<"0.7">
+const SmartAccountConfigSchema = z.object({
+  kernelVersion: z.enum(["0.3.0", "0.3.1", "0.3.2", "0.3.3"]),
+  index: z.number().int().min(0).default(0),
+});
+
 const PrivyConfigSchema = z.object({
   jwksUrl: z.url(),
   appId: z.string().min(1),
+  smartAccount: SmartAccountConfigSchema.optional(),
 });
 
 type ParaConfig = z.infer<typeof ParaConfigSchema>;
@@ -347,11 +355,17 @@ export class Distributor {
       throw new Error(`Invalid Privy token: ${result.error}`);
     }
 
-    const wallet = getPrivyEmbeddedWallet(result.payload);
+    const signer = getPrivyEmbeddedWallet(result.payload);
+
+    const wallet = config.smartAccount
+      ? await deriveKernelAddress(signer, config.smartAccount)
+      : signer;
 
     if (requestId) {
       log.debug("Privy wallet resolved", "distributor", requestId, {
         wallet,
+        signer,
+        smartAccount: !!config.smartAccount,
         userId: result.payload.sub,
         ...this.getLogContext(),
       });

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,11 @@ export interface DistributorConfig {
   erc20Configs?: ERC20Config[]; 
 }
 
+export interface SmartAccountConfig {
+  kernelVersion: "0.3.0" | "0.3.1" | "0.3.2" | "0.3.3";
+  index: number;
+}
+
 export interface ERC20Config {
   tokenAddress: string;
   amount: string; // Amount in human-readable format (e.g., "100.5")

--- a/src/utils/smartAccount.test.ts
+++ b/src/utils/smartAccount.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "bun:test";
+import { deriveKernelAddress } from "./smartAccount";
+
+// Pinned against fluent-connect-sdk packages/react/src/zerodevSession.ts:455-468.
+// If this breaks, the frontend and the faucet no longer agree on where a user's
+// funds go - do not update the expected value without checking the SDK first.
+describe("deriveKernelAddress", () => {
+  it("derives the Kernel v0.3.3 address the Fluent Connect widget shows", async () => {
+    const address = await deriveKernelAddress(
+      "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+      { kernelVersion: "0.3.3", index: 0 },
+    );
+
+    expect(address).toBe("0xCfC4C807Ed404ae1a65fbe0EdaA09EF002E75838");
+  });
+
+  it("rejects a malformed signer instead of deriving an unreachable address", async () => {
+    for (const signer of ["", "0x", "0xdeadbeef", "not-an-address"]) {
+      expect(
+        deriveKernelAddress(signer, { kernelVersion: "0.3.3", index: 0 }),
+      ).rejects.toThrow("Invalid signer address");
+    }
+  });
+});

--- a/src/utils/smartAccount.ts
+++ b/src/utils/smartAccount.ts
@@ -1,0 +1,30 @@
+import { getKernelAddressFromECDSA } from "@zerodev/ecdsa-validator";
+import { getEntryPoint } from "@zerodev/sdk/constants";
+import { createPublicClient, http, isAddress, type Address } from "viem";
+import type { SmartAccountConfig } from "../types";
+
+// EntryPoint 0.7 derives the address purely from constants - CREATE2 over the
+// account implementation address. The client is required by the signature but
+// never dialled; only the 0.6 path reads initCodeHash from the factory.
+const offlineClient = createPublicClient({
+  transport: http("http://127.0.0.1:1"),
+});
+
+export async function deriveKernelAddress(
+  signer: string,
+  config: SmartAccountConfig,
+): Promise<Address> {
+  // CREATE2 hashes whatever it is given - an unvalidated signer would derive a
+  // well-formed address that no one controls, and payout would succeed.
+  if (!isAddress(signer)) {
+    throw new Error(`Invalid signer address: ${signer}`);
+  }
+
+  return await getKernelAddressFromECDSA({
+    publicClient: offlineClient,
+    eoaAddress: signer,
+    index: BigInt(config.index),
+    entryPoint: getEntryPoint("0.7"),
+    kernelVersion: config.kernelVersion,
+  });
+}


### PR DESCRIPTION
- derive kernel address offline from the privy jwt signer
- opt-in per distributor via smartAccount config block
- other privy endpoints keep paying the embedded wallet
- reject a malformed signer before any funds move
- pin signer -> address to catch drift from the sdk